### PR TITLE
fix: mis-matched variable names cause validation errors on /admin/config/people/simple_oauth/oauth-21/server-metadata

### DIFF
--- a/modules/simple_oauth_native_apps/src/Service/ConfigurationValidator.php
+++ b/modules/simple_oauth_native_apps/src/Service/ConfigurationValidator.php
@@ -72,7 +72,7 @@ class ConfigurationValidator {
 
     // Validate detection policy.
     $valid_policies = ['off', 'warn', 'block'];
-    $detection_policy = $config['webview']['detection'] ?? '';
+    $detection_policy = $config['webview_detection'] ?? '';
     if (!in_array($detection_policy, $valid_policies, TRUE)) {
       $errors[] = $this->t('Invalid WebView detection policy. Must be one of: @policies', [
         '@policies' => implode(', ', $valid_policies),
@@ -112,7 +112,7 @@ class ConfigurationValidator {
 
     // Check for logical conflicts.
     if (!empty($config['require_exact_redirect_match']) &&
-        (empty($config['allow']['custom_uri_schemes']) && empty($config['allow']['loopback_redirects']))) {
+      (empty($config['allow_custom_uri_schemes']) && empty($config['allow_loopback_redirects']))) {
       $errors[] = $this->t('Requiring exact redirect match without allowing custom schemes or loopback redirects may prevent native apps from functioning properly.');
     }
 


### PR DESCRIPTION
Without this fix it's impossible to submit the form at fig/people/simple_oauth/oauth-21/server-metadata without errors. Validation will always fail because of the mis-matched variable names.