### PR TITLE
Add missing dependency on drupal/simple_oauth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
       "email": "mateu@mateuaguilo.com"
     }
   ],
+  "require": {
+    "drupal/simple_oauth": "^6.0.3"
+  }
   "require-dev": {
     "drupal/coder": "^8",
     "phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "drupal/simple_oauth": "^6.0.3"
-  }
+  },
   "require-dev": {
     "drupal/coder": "^8",
     "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
In contradiction with Drupal Packagist, Packagist.org is not going to infer dependencies from info.yml and automatically add them to composer.json. 

(I have just tried to install this module on my local and then I realized the main module dependency is missing.)