### PR TITLE
bug: local task definitions should belong to the module that defines the route

### DIFF
--- a/modules/simple_oauth_client_registration/simple_oauth_client_registration.links.task.yml
+++ b/modules/simple_oauth_client_registration/simple_oauth_client_registration.links.task.yml
@@ -1,0 +1,6 @@
+# Client Registration tab under OAuth 2.1 Compliance
+simple_oauth_21.client_registration:
+  route_name: simple_oauth_client_registration.settings
+  title: 'Client Registration'
+  parent_id: simple_oauth_21.oauth21_compliance
+  weight: 40

--- a/modules/simple_oauth_native_apps/simple_oauth_native_apps.links.task.yml
+++ b/modules/simple_oauth_native_apps/simple_oauth_native_apps.links.task.yml
@@ -1,0 +1,6 @@
+# Native Apps tab under OAuth 2.1 Compliance
+simple_oauth_21.native_apps:
+  route_name: simple_oauth_native_apps.settings
+  title: 'Native Apps'
+  parent_id: simple_oauth_21.oauth21_compliance
+  weight: 20

--- a/modules/simple_oauth_pkce/simple_oauth_pkce.links.task.yml
+++ b/modules/simple_oauth_pkce/simple_oauth_pkce.links.task.yml
@@ -1,0 +1,6 @@
+# PKCE tab under OAuth 2.1 Compliance
+simple_oauth_21.pkce:
+  route_name: simple_oauth_pkce.settings
+  title: 'PKCE'
+  parent_id: simple_oauth_21.oauth21_compliance
+  weight: 30

--- a/modules/simple_oauth_server_metadata/simple_oauth_server_metadata.links.task.yml
+++ b/modules/simple_oauth_server_metadata/simple_oauth_server_metadata.links.task.yml
@@ -1,0 +1,6 @@
+# Server Metadata tab under OAuth 2.1 Compliance
+simple_oauth_21.server_metadata:
+  route_name: simple_oauth_server_metadata.settings
+  title: 'Server Metadata'
+  parent_id: simple_oauth_21.oauth21_compliance
+  weight: 10

--- a/simple_oauth_21.links.task.yml
+++ b/simple_oauth_21.links.task.yml
@@ -11,31 +11,3 @@ simple_oauth_21.dashboard:
   title: 'Dashboard'
   parent_id: simple_oauth_21.oauth21_compliance
   weight: 0
-
-# Server Metadata tab under OAuth 2.1 Compliance
-simple_oauth_21.server_metadata:
-  route_name: simple_oauth_server_metadata.settings
-  title: 'Server Metadata'
-  parent_id: simple_oauth_21.oauth21_compliance
-  weight: 10
-
-# Native Apps tab under OAuth 2.1 Compliance
-simple_oauth_21.native_apps:
-  route_name: simple_oauth_native_apps.settings
-  title: 'Native Apps'
-  parent_id: simple_oauth_21.oauth21_compliance
-  weight: 20
-
-# PKCE tab under OAuth 2.1 Compliance
-simple_oauth_21.pkce:
-  route_name: simple_oauth_pkce.settings
-  title: 'PKCE'
-  parent_id: simple_oauth_21.oauth21_compliance
-  weight: 30
-
-# Client Registration tab under OAuth 2.1 Compliance
-simple_oauth_21.client_registration:
-  route_name: simple_oauth_client_registration.settings
-  title: 'Client Registration'
-  parent_id: simple_oauth_21.oauth21_compliance
-  weight: 40


### PR DESCRIPTION
Move local task definitions for sub-module routes into the sub-module that defines the route. This fixes an issue where if you enable simple_oauth_21, and try and visit /admin/config/people/simple_oauth/oauth-21 but not all the sub-modules are enabled you get an error. The error is caused by Drupal attempting to render all the local task tabs, but some of them point to routes that don't exist if the corresponding sub-module doesn't exist.