### PR TITLE
Simple Oauth : Additional Claims Supported

### DIFF
--- a/modules/simple_oauth_server_metadata/src/SimpleOauthServerMetadataServiceProvider.php
+++ b/modules/simple_oauth_server_metadata/src/SimpleOauthServerMetadataServiceProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Drupal\simple_oauth_server_metadata;
 
 use Drupal\Core\Database\Database;
@@ -25,8 +23,6 @@ class SimpleOauthServerMetadataServiceProvider extends ServiceProviderBase {
       : [];
 
     // Try to load additional_claims_supported from config.
-    // We need to access the database directly since the config factory
-    // is not yet available during container building.
     $additional_claims = $this->getAdditionalClaimsFromConfig();
 
     if (!empty($additional_claims)) {
@@ -39,25 +35,29 @@ class SimpleOauthServerMetadataServiceProvider extends ServiceProviderBase {
   /**
    * Gets additional claims from config via direct database query.
    *
-   * @return array
+   * Direct database access is required here because the config factory
+   * is not yet available during container building in a ServiceProvider.
+   *
+   * @return array<string>
    *   The additional claims supported, or empty array if not found.
    */
   private function getAdditionalClaimsFromConfig(): array {
     try {
-      $db = Database::getConnection('default');
-      $result = $db->query(
-        "SELECT data FROM {config} WHERE name = :name",
-        [':name' => 'simple_oauth_server_metadata.settings']
-      )->fetchField();
+      $connection = Database::getConnection('default');
+      $result = $connection->select('config', 'c')
+        ->fields('c', ['data'])
+        ->condition('name', 'simple_oauth_server_metadata.settings')
+        ->execute()
+        ->fetchField();
 
-      if ($result) {
+      if ($result !== FALSE && is_string($result)) {
         $config = unserialize($result, ['allowed_classes' => FALSE]);
-        if (isset($config['additional_claims_supported']) && is_array($config['additional_claims_supported'])) {
+        if (is_array($config) && isset($config['additional_claims_supported']) && is_array($config['additional_claims_supported'])) {
           return $config['additional_claims_supported'];
         }
       }
     }
-    catch (\Exception $e) {
+    catch (\Exception) {
       // Config table may not exist yet during installation.
     }
 

--- a/modules/simple_oauth_server_metadata/src/SimpleOauthServerMetadataServiceProvider.php
+++ b/modules/simple_oauth_server_metadata/src/SimpleOauthServerMetadataServiceProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simple_oauth_server_metadata;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Service provider for the simple_oauth_server_metadata module.
+ *
+ * Merges additional_claims_supported from config with the base OpenID claims.
+ */
+class SimpleOauthServerMetadataServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    // Get current claims parameter.
+    $claims = $container->hasParameter('simple_oauth.openid.claims')
+      ? $container->getParameter('simple_oauth.openid.claims')
+      : [];
+
+    // Try to load additional_claims_supported from config.
+    // We need to access the database directly since the config factory
+    // is not yet available during container building.
+    $additional_claims = $this->getAdditionalClaimsFromConfig();
+
+    if (!empty($additional_claims)) {
+      // Merge additional claims with existing claims.
+      $merged_claims = array_unique(array_merge($claims, $additional_claims));
+      $container->setParameter('simple_oauth.openid.claims', $merged_claims);
+    }
+  }
+
+  /**
+   * Gets additional claims from config via direct database query.
+   *
+   * @return array
+   *   The additional claims supported, or empty array if not found.
+   */
+  private function getAdditionalClaimsFromConfig(): array {
+    try {
+      $db = Database::getConnection('default');
+      $result = $db->query(
+        "SELECT data FROM {config} WHERE name = :name",
+        [':name' => 'simple_oauth_server_metadata.settings']
+      )->fetchField();
+
+      if ($result) {
+        $config = unserialize($result, ['allowed_classes' => FALSE]);
+        if (isset($config['additional_claims_supported']) && is_array($config['additional_claims_supported'])) {
+          return $config['additional_claims_supported'];
+        }
+      }
+    }
+    catch (\Exception $e) {
+      // Config table may not exist yet during installation.
+    }
+
+    return [];
+  }
+
+}


### PR DESCRIPTION
Hi @e0ipso ,

After installing simple_oauth_21 on my Drupal site, I noticed that additional claims configured via the Server Metadata Config are not being included in the OpenID Connect responses.
Please review and merge the attached pull request, which adds support for including these configured additional claims in the OIDC flow.